### PR TITLE
More than 2 teams

### DIFF
--- a/balance.py
+++ b/balance.py
@@ -45,21 +45,25 @@ def indexIntoLine(index, line_list):
 
 #Takes in a list of players and partitions them into two
 #teams using least difference heuristic
-def partition(player_list, weight):
-    red_team = []
-    red_team_sum = 0
-    blue_team = []
-    blue_team_sum = 0
+def partition(player_list, weight, number_of_teams):
+    teams = []
+    sums = []
+    for i in range(0, number_of_teams): # Create array for each team
+        teams.append([])
+        sums.append(0);
+
     for p in player_list:
-        if red_team_sum < blue_team_sum:
-            red_team.append(p)
-            red_team_sum += p.getSort(weight)
-        else:
-            blue_team.append(p)
-            blue_team_sum += p.getSort(weight)
-    if (len(red_team) != len(blue_team)):
+        shortest_len = -1
+        shortest_index = 0
+        for i, team in enumerate(teams):
+            if (len(team) < shortest_len) or (shortest_len == -1):
+                shortest_len = len(team)
+                shortest_index = i
+        teams[shortest_index].append(p)
+        sums[shortest_index] += p.getSort(weight)
+    if not all([len(team) == len(teams[0]) for team in teams]):
         print ("No balanced partition found for %s!" % weight)
-    return red_team, red_team_sum, blue_team, blue_team_sum
+    return teams, sums
 
 
 
@@ -93,15 +97,20 @@ def savePlayers(player_list, known_player_file):
     return
 
 if __name__ == "__main__":
+    # Input number of teams to produce
+    number_of_teams = int(input("Enter number of teams: "))
+
     # Initialize the players
     players = readPlayers('players.txt', 'knownplayers.txt')
     players.sort(key=lambda x: x.getSR(), reverse=True)
     weights = ['Curve', 'Flat', 'Tier', 'Rand', 'Throw']
     
     for weight in weights:
-        red_team, r_sum, blue_team, b_sum = partition(players, weight)
-        printTeam(red_team, r_sum, weight)
-        printTeam(blue_team, b_sum, weight)
+        teams, sums = partition(players, weight, number_of_teams)
+        print("\n\n")
+        for index, team in enumerate(teams):
+            print("Team %s" % str(index + 1))
+            printTeam(team, sums[index], weight)
 
     # Save players to prevent constant lookups
     savePlayers(players, 'knownplayers.txt')

--- a/balance.py
+++ b/balance.py
@@ -46,6 +46,7 @@ def indexIntoLine(index, line_list):
 #Takes in a list of players and partitions them into two
 #teams using least difference heuristic
 def partition(player_list, weight, number_of_teams):
+    player_list.sort(key=lambda x: x.getSR(), reverse=True)
     teams = []
     sums = []
     for i in range(0, number_of_teams): # Create array for each team
@@ -55,13 +56,13 @@ def partition(player_list, weight, number_of_teams):
     for p in player_list:
         shortest_len = -1
         shortest_index = 0
-        for i, team in enumerate(teams):
+        for i, team in enumerate(teams): # Get team with lowest sum
             if (len(team) < shortest_len) or (shortest_len == -1):
                 shortest_len = len(team)
                 shortest_index = i
-        teams[shortest_index].append(p)
+        teams[shortest_index].append(p) # Add player to lowest sum team
         sums[shortest_index] += p.getSort(weight)
-    if not all([len(team) == len(teams[0]) for team in teams]):
+    if not all([len(team) == len(teams[0]) for team in teams]): # If not all teams are the same length
         print ("No balanced partition found for %s!" % weight)
     return teams, sums
 

--- a/balance.py
+++ b/balance.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     weights = ['Curve', 'Flat', 'Tier', 'Rand', 'Throw']
     
     for weight in weights:
-        teams, sums = partition(players, weight, number_of_teams)
         print("\n\n")
+        teams, sums = partition(players, weight, number_of_teams)
         for index, team in enumerate(teams):
             print("Team %s" % str(index + 1))
             printTeam(team, sums[index], weight)

--- a/balance.py
+++ b/balance.py
@@ -54,14 +54,14 @@ def partition(player_list, weight, number_of_teams):
         sums.append(0);
 
     for p in player_list:
-        shortest_len = -1
-        shortest_index = 0
+        lowest_sum = -1
+        lowest_index = 0
         for i, team in enumerate(teams): # Get team with lowest sum
-            if (len(team) < shortest_len) or (shortest_len == -1):
-                shortest_len = len(team)
-                shortest_index = i
-        teams[shortest_index].append(p) # Add player to lowest sum team
-        sums[shortest_index] += p.getSort(weight)
+            if (sums[i] < lowest_sum) or (lowest_sum == -1):
+                lowest_sum = sums[i]
+                lowest_index = i
+        teams[lowest_index].append(p) # Add player to lowest sum team
+        sums[lowest_index] += p.getSort(weight)
     if not all([len(team) == len(teams[0]) for team in teams]): # If not all teams are the same length
         print ("No balanced partition found for %s!" % weight)
     return teams, sums

--- a/balancer.py
+++ b/balancer.py
@@ -31,14 +31,14 @@ class Balancer:
             sums.append(0);
 
         for p in player_list:
-            shortest_len = -1
-            shortest_index = 0
+            lowest_sum = -1
+            lowest_index = 0
             for i, team in enumerate(teams):  # Get team with lowest sum
-                if (len(team) < shortest_len) or (shortest_len == -1):
-                    shortest_len = len(team)
-                    shortest_index = i
-            teams[shortest_index].append(p)  # Add player to lowest sum team
-            sums[shortest_index] += p.getSort(weight)
+                if (sums[i] < lowest_sum) or (lowest_sum == -1):
+                    lowest_sum = sums[i]
+                    lowest_index = i
+            teams[lowest_index].append(p)  # Add player to lowest sum team
+            sums[lowest_index] += p.getSort(weight)
         if not all([len(team) == len(teams[0]) for team in teams]):  # If not all teams are the same length
             message = "No balanced partition found for " + weight
         else :

--- a/balancer.py
+++ b/balancer.py
@@ -2,7 +2,7 @@ class Balancer:
     def __init__(self):
         return
 
-    def partition(self, player_list, weight):    
+    def partition(self, player_list, weight):
         player_list.sort(key=lambda x: x.getSR(), reverse=True)
         red_team = []
         red_team_sum = 0
@@ -20,7 +20,7 @@ class Balancer:
         else:
             message = "Created balanced partition for " + weight
         return message, red_team, blue_team
-        
+
 
 # Gonna make it look real nice
     def printTeam(self, t_name, team, weight):

--- a/balancer.py
+++ b/balancer.py
@@ -21,6 +21,29 @@ class Balancer:
             message = "Created balanced partition for " + weight
         return message, red_team, blue_team
 
+    # Supports balancing multiple teams
+    def partitionMultipleTeams(self, player_list, weight, number_of_teams): # TODO: Phase out regular partition function, replace with this
+        player_list.sort(key=lambda x: x.getSR(), reverse=True)
+        teams = []
+        sums = []
+        for i in range(0, number_of_teams):  # Create array for each team
+            teams.append([])
+            sums.append(0);
+
+        for p in player_list:
+            shortest_len = -1
+            shortest_index = 0
+            for i, team in enumerate(teams):  # Get team with lowest sum
+                if (len(team) < shortest_len) or (shortest_len == -1):
+                    shortest_len = len(team)
+                    shortest_index = i
+            teams[shortest_index].append(p)  # Add player to lowest sum team
+            sums[shortest_index] += p.getSort(weight)
+        if not all([len(team) == len(teams[0]) for team in teams]):  # If not all teams are the same length
+            message = "No balanced partition found for " + weight
+        else :
+            message = "Created balanced partition for " + weight
+        return message, teams, sums
 
 # Gonna make it look real nice
     def printTeam(self, t_name, team, weight):

--- a/scrimbot.py
+++ b/scrimbot.py
@@ -220,7 +220,7 @@ async def autobalance(*args):
     message_list = []
     for weight in args:
         sc = scrim.Scrim(weight)
-        status, red_team, blue_team = balancer.partition(active_players, weight)
+        status, red_team, blue_team = balancer.partition(active_players, weight) # TODO: convert to multi-team (>2) partition function
         await bot.say(status)
         sc.setTeams(red_team, blue_team)
         message_list.append(balancer.printTeam("Red Team", red_team, weight))


### PR DESCRIPTION
Changes allow more than 2 teams to be generated from the balancer. Currently only supported in standalone version (Bot not supported yet), new method added to balancer.py to be used with the bot in the future.

Partition method now returns a list of teams and a list of sums, which can be iterated through to output teams. The index of a team within the teams array is the same as the index of their sum in the sums array.

Added extra spacing between different weighting types, as it was hard to read previously when displaying more than 2 teams.